### PR TITLE
Fix: global table changelog standbys not receiving updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Note: This project is a fork of the original **Faust** stream processing library
 
 |build-status| |coverage| |license| |wheel| |pyversion| |pyimp|
 
-:Version: 1.15.1
+:Version: 1.15.2
 :Web: http://faust.readthedocs.io/
 :Download: http://pypi.org/project/faust
 :Source: http://github.com/robinhood/faust

--- a/faust/tables/recovery.py
+++ b/faust/tables/recovery.py
@@ -606,7 +606,7 @@ class Recovery(Service):
         self.log.dev('Resume stream partitions')
         consumer.resume_partitions({
             tp for tp in assignment
-            if not self._is_changelog_tp(tp)
+            if self._is_global_table_tp(tp) or not self._is_changelog_tp(tp)
         })
         # finally make sure the fetcher is running.
         await cast(_App, self.app)._fetcher.maybe_start()
@@ -1032,3 +1032,7 @@ class Recovery(Service):
 
     def _is_changelog_tp(self, tp: TP) -> bool:
         return tp.topic in self.tables.changelog_topics
+
+    def _is_global_table_tp(self, tp: TP) -> bool:
+        return tp.topic in self.tables._changelogs \
+            and self.tables._changelogs[tp.topic].is_global

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.15.1
+current_version = 1.15.2
 commit = true
 tag = true
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<releaselevel>[a-z]+)?


### PR DESCRIPTION
* Consumer resumes consumption of events for global table standby tps after recovery
