### PR TITLE
Fix: Send with partition not working

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Note: This project is a fork of the original **Faust** stream processing library
 
 |build-status| |coverage| |license| |wheel| |pyversion| |pyimp|
 
-:Version: 1.16.2
+:Version: 1.16.5
 :Web: http://faust.readthedocs.io/
 :Download: http://pypi.org/project/faust
 :Source: http://github.com/robinhood/faust

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Note: This project is a fork of the original **Faust** stream processing library
 
 |build-status| |coverage| |license| |wheel| |pyversion| |pyimp|
 
-:Version: 1.16.3
+:Version: 1.16.2
 :Web: http://faust.readthedocs.io/
 :Download: http://pypi.org/project/faust
 :Source: http://github.com/robinhood/faust

--- a/faust/__init__.py
+++ b/faust/__init__.py
@@ -24,7 +24,7 @@ import typing
 
 from typing import Any, Mapping, NamedTuple, Optional, Sequence, Tuple
 
-__version__ = '1.16.3'
+__version__ = '1.16.2'
 __author__ = 'Robinhood Markets, Inc.'
 __contact__ = 'contact@fauststream.com'
 __homepage__ = 'http://faust.readthedocs.io/'

--- a/faust/__init__.py
+++ b/faust/__init__.py
@@ -24,7 +24,7 @@ import typing
 
 from typing import Any, Mapping, NamedTuple, Optional, Sequence, Tuple
 
-__version__ = '1.16.2'
+__version__ = '1.16.5'
 __author__ = 'Robinhood Markets, Inc.'
 __contact__ = 'contact@fauststream.com'
 __homepage__ = 'http://faust.readthedocs.io/'

--- a/faust/assignor/partition_assignor.py
+++ b/faust/assignor/partition_assignor.py
@@ -1,8 +1,6 @@
 """Partition assignor."""
 import socket
 import zlib
-import os
-import signal
 
 from collections import defaultdict
 from typing import (
@@ -130,13 +128,8 @@ class PartitionAssignor(
         a = sorted(assignment.assignment)
         b = sorted(
             self._assignment.kafka_protocol_assignment(self._table_manager))
-        if a != b:
-            # Not sure how we can cleanly recover from a assignment mismatch 
-            # so we kill the process and assume a restart.
-            logger.error(f'Assignment mismatch: {a!r} != {b!r}')
-            os.kill(os.getpid(), signal.SIGKILL)
         assert a == b, f'{a!r} != {b!r}'
-        assert metadata.url == str(self._url)            
+        assert metadata.url == str(self._url)
 
     def metadata(self, topics: Set[str]) -> ConsumerProtocolMemberMetadata:
         return ConsumerProtocolMemberMetadata(self.version, list(topics),

--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -339,6 +339,8 @@ class TransactionManager(Service, TransactionManagerT):
         if p is not None:
             group = self.app.assignor.group_for_topic(topic)
             transactional_id = f'{self.app.conf.id}-{group}-{p}'
+        elif partition is not None:
+            p = partition            
         return await self.producer.send(
             topic, key, value, p, timestamp, headers,
             transactional_id=transactional_id,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.16.2
+current_version = 1.16.5
 commit = true
 tag = true
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<releaselevel>[a-z]+)?

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.16.3
+current_version = 1.16.2
 commit = true
 tag = true
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<releaselevel>[a-z]+)?


### PR DESCRIPTION
* Fixes issue where send does not produce to correct partition when a partition is explicitly provided.
* Rollback previous change to crash on partition assignment mismatch error
* Bump to v1.16.5