### PR TITLE
Fix duplicate consumption & off by one lag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Note: This project is a fork of the original **Faust** stream processing library
 
 |build-status| |coverage| |license| |wheel| |pyversion| |pyimp|
 
-:Version: 1.16.5
+:Version: 1.16.6
 :Web: http://faust.readthedocs.io/
 :Download: http://pypi.org/project/faust
 :Source: http://github.com/robinhood/faust

--- a/faust/__init__.py
+++ b/faust/__init__.py
@@ -24,7 +24,7 @@ import typing
 
 from typing import Any, Mapping, NamedTuple, Optional, Sequence, Tuple
 
-__version__ = '1.16.5'
+__version__ = '1.16.6'
 __author__ = 'Robinhood Markets, Inc.'
 __contact__ = 'contact@fauststream.com'
 __homepage__ = 'http://faust.readthedocs.io/'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.16.5
+current_version = 1.16.6
 commit = true
 tag = true
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<releaselevel>[a-z]+)?

--- a/t/unit/stores/test_base.py
+++ b/t/unit/stores/test_base.py
@@ -121,6 +121,9 @@ class MySerializedStore(SerializedStore):
     def reset_state(self):
         ...
 
+    def _prefix_scan(self, prefix: bytes):
+        ...        
+
 
 class test_SerializedStore:
 


### PR DESCRIPTION
* Fix an issue where the consumer would re-consume the last committed topic/partition message on start up.
* Fixes the "off by one" problem where a fully caught up consumer would report a lag of 1 for every topic, partition.
* Fixes error in `stores` test