### PR TITLE
Improvements to key join

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Note: This project is a fork of the original **Faust** stream processing library
 
 |build-status| |coverage| |license| |wheel| |pyversion| |pyimp|
 
-:Version: 1.17.10
+:Version: 1.17.11
 :Web: http://faust.readthedocs.io/
 :Download: http://pypi.org/project/faust
 :Source: http://github.com/robinhood/faust

--- a/faust/__init__.py
+++ b/faust/__init__.py
@@ -24,7 +24,7 @@ import typing
 
 from typing import Any, Mapping, NamedTuple, Optional, Sequence, Tuple
 
-__version__ = '1.17.10'
+__version__ = '1.17.11'
 __author__ = 'Robinhood Markets, Inc.'
 __contact__ = 'contact@fauststream.com'
 __homepage__ = 'http://faust.readthedocs.io/'

--- a/faust/tables/keyjoin.py
+++ b/faust/tables/keyjoin.py
@@ -1,7 +1,7 @@
 """Key Join — subscription/response protocol (KIP-213)."""
 import mmh3
 import asyncio
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
 
 from mode import Service
 
@@ -173,19 +173,17 @@ class KeyJoinProcessor(Service, KeyJoinT):
             self._previous_fk = self._create_previous_fk_store()
         return self._previous_fk
 
-    def prefix_scan(self, fk: Any) -> List[Tuple[Any, Dict[str, Any]]]:
-        """Return all subscription entries for a given FK.
+    def prefix_scan(self, fk: Any) -> Iterator[Tuple[Any, Dict[str, Any]]]:
+        """Yield all subscription entries for a given FK.
 
         Uses the subscription store's ``prefix_scan`` to find all
         composite keys ``"{fk}\\x00{left_pk}"`` matching the FK prefix
-        and returns ``[(left_pk, entry), ...]``.
+        and yields ``(left_pk, entry)`` pairs.
         """
         prefix = f"{fk}\x00"
-        results = []
         for key, value in self.subscription_store.prefix_scan(prefix):
             left_pk = key[len(prefix):]
-            results.append((left_pk, value))
-        return results
+            yield (left_pk, value)
 
     # --- Group 4: Hash Computation ---
 
@@ -297,9 +295,7 @@ class KeyJoinProcessor(Service, KeyJoinT):
     ) -> None:
         """Called when the right table is updated."""
         right_value = None if is_delete else value
-        subscribers = self.prefix_scan(key)
-
-        for left_pk, entry in subscribers:
+        for left_pk, entry in self.prefix_scan(key):
             response = { "right_value": right_value, "hash": entry.get('hash', 0) }
             partition = self.app.producer.key_partition(current_event().message.topic, self._serialize_left_pk(left_pk)).partition
             self.response_topic.send_soon(key=left_pk, value=response, partition=partition)

--- a/faust/tables/keyjoin.py
+++ b/faust/tables/keyjoin.py
@@ -203,6 +203,24 @@ class KeyJoinProcessor(Service, KeyJoinT):
             data = codecs.dumps('json', value)
         return mmh3.hash128(data)
 
+    # --- Helpers: Key Serialization ---
+
+    def _serialize_fk(self, fk: Any) -> bytes:
+        """Serialize a foreign key using the right table's key serializer."""
+        return self.app.serializers.dumps_key(
+            self.right_table.key_type,
+            fk,
+            serializer=self.right_table.key_serializer,
+        )
+
+    def _serialize_left_pk(self, left_pk: Any) -> bytes:
+        """Serialize a left primary key using the left table's key serializer."""
+        return self.app.serializers.dumps_key(
+            self.left_table.key_type,
+            left_pk,
+            serializer=self.left_table.key_serializer,
+        )
+
     # --- Group 5: Left-Side Subscription Sender ---
 
     def _on_left_table_change(
@@ -246,7 +264,7 @@ class KeyJoinProcessor(Service, KeyJoinT):
         instruction: SubscriptionInstruction,
     ) -> None:
         msg = { "left_pk": left_pk, "hash": hash_value, "instruction": instruction.value }
-        partition = self.app.producer.key_partition(current_event().message.topic, fk.encode()).partition
+        partition = self.app.producer.key_partition(current_event().message.topic, self._serialize_fk(fk)).partition
         self.subscription_topic.send_soon(key=fk, value=msg, partition=partition)
 
     # --- Group 6: Right-Side Subscription Processor ---
@@ -269,7 +287,7 @@ class KeyJoinProcessor(Service, KeyJoinT):
             right_value = self.right_table.get(fk)
             left_pk = message.get('left_pk')
             response = { "right_value": right_value, "hash": message.get('hash', 0) }
-            partition = self.app.producer.key_partition(current_event().message.topic, left_pk.encode()).partition
+            partition = self.app.producer.key_partition(current_event().message.topic, self._serialize_left_pk(left_pk)).partition
             await self.response_topic.send(key=left_pk, value=response, partition=partition)
 
     # --- Group 7: Right-Table Update Propagation ---
@@ -283,7 +301,7 @@ class KeyJoinProcessor(Service, KeyJoinT):
 
         for left_pk, entry in subscribers:
             response = { "right_value": right_value, "hash": entry.get('hash', 0) }
-            partition = self.app.producer.key_partition(current_event().message.topic, left_pk.encode()).partition
+            partition = self.app.producer.key_partition(current_event().message.topic, self._serialize_left_pk(left_pk)).partition
             self.response_topic.send_soon(key=left_pk, value=response, partition=partition)
 
     # --- Group 8: Left-Side Response Handler ---

--- a/faust/types/tables.py
+++ b/faust/types/tables.py
@@ -249,6 +249,25 @@ class CollectionT(ServiceT, JoinableT):
         """Join this table with another table based on a key extractor."""
         ...
 
+    @abc.abstractmethod
+    def register_on_key_set(self, callback: Callable) -> None:
+        """Register a callback to be called on key set."""
+        ...
+
+    @abc.abstractmethod
+    def unregister_on_key_set(self, callback: Callable) -> None:
+        """Unregister a key-set callback (no-op if not registered)."""
+        ...
+
+    @abc.abstractmethod
+    def register_on_key_del(self, callback: Callable) -> None:
+        """Register a callback to be called on key delete."""
+        ...
+
+    @abc.abstractmethod
+    def unregister_on_key_del(self, callback: Callable) -> None:
+        """Unregister a key-del callback (no-op if not registered)."""
+        ...
 
 class TableT(CollectionT, ManagedUserDict[KT, VT]):
     ...

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.17.10
+current_version = 1.17.11
 commit = true
 tag = true
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<releaselevel>[a-z]+)?


### PR DESCRIPTION
Improvements to the key-join table logic, particularly around key serialization and callback registration for key events. The changes enhance type safety and extensibility, and improve the handling of key serialization in distributed table operations.

Key-join table improvements:

* Changed the `prefix_scan` method in `faust/tables/keyjoin.py` to return an iterator instead of a list, allowing for more memory-efficient iteration over subscription entries.
* Added helper methods `_serialize_fk` and `_serialize_left_pk` to handle key serialization using the appropriate table key serializers, improving correctness and consistency when partitioning messages.
* Updated partitioning logic in `_send_subscription`, `_process_subscription`, and `_on_right_table_change` to use the new serialization helpers instead of calling `.encode()` directly, ensuring proper key serialization for Kafka partitioning. [[1]](diffhunk://#diff-c448f6d8368aa69cb8b3f520ba5c9efb684066e1be99b9ddd771a438e43be198L249-R265) [[2]](diffhunk://#diff-c448f6d8368aa69cb8b3f520ba5c9efb684066e1be99b9ddd771a438e43be198L272-R288) [[3]](diffhunk://#diff-c448f6d8368aa69cb8b3f520ba5c9efb684066e1be99b9ddd771a438e43be198L282-R300)

Type and interface enhancements:

* Added abstract methods to `TableManagerT` in `faust/types/tables.py` for registering and unregistering callbacks on key set and key delete events, making it easier to extend and respond to table key changes.

Version bump and metadata:

* Bumped the project version from 1.17.10 to 1.17.11 in `README.rst`, `faust/__init__.py`, and `setup.cfg`. [[1]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL13-R13) [[2]](diffhunk://#diff-7c55f4cc141fccbe3944636359af465ca04864c431abf98e102437cd969463ecL27-R27) [[3]](diffhunk://#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52L2-R2)