### PR TITLE
fix recovery None checks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Note: This project is a fork of the original **Faust** stream processing library
 
 |build-status| |coverage| |license| |wheel| |pyversion| |pyimp|
 
-:Version: 1.17.11
+:Version: 1.17.12
 :Web: http://faust.readthedocs.io/
 :Download: http://pypi.org/project/faust
 :Source: http://github.com/robinhood/faust

--- a/faust/__init__.py
+++ b/faust/__init__.py
@@ -24,7 +24,7 @@ import typing
 
 from typing import Any, Mapping, NamedTuple, Optional, Sequence, Tuple
 
-__version__ = '1.17.11'
+__version__ = '1.17.12'
 __author__ = 'Robinhood Markets, Inc.'
 __contact__ = 'contact@fauststream.com'
 __homepage__ = 'http://faust.readthedocs.io/'

--- a/faust/tables/recovery.py
+++ b/faust/tables/recovery.py
@@ -847,7 +847,7 @@ class Recovery(Service):
         return Counter({
             tp: highwater - offsets[tp]
             for tp, highwater in highwaters.items()
-            if highwater >= 0 and offsets[tp] >= 0
+            if highwater is not None and offsets[tp] is not None
         })
 
     def active_remaining_total(self) -> int:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.17.11
+current_version = 1.17.12
 commit = true
 tag = true
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<releaselevel>[a-z]+)?


### PR DESCRIPTION
Bump package version to 1.17.12. In faust/tables/recovery.py, replace numeric >= 0 checks with explicit is not None checks for highwater and offsets in the remaining calculation. This avoids invalid comparisons with None and ensures entries with non-None (including negative) values are handled correctly.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://faust.readthedocs.io/en/master/contributing.html).

## Description

Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
