### PR TITLE
Handle empty assignment on revoke and cleanup

### DIFF
--- a/faust/__init__.py
+++ b/faust/__init__.py
@@ -24,7 +24,7 @@ import typing
 
 from typing import Any, Mapping, NamedTuple, Optional, Sequence, Tuple
 
-__version__ = '1.17.12'
+__version__ = '1.17.13'
 __author__ = 'Robinhood Markets, Inc.'
 __contact__ = 'contact@fauststream.com'
 __homepage__ = 'http://faust.readthedocs.io/'

--- a/faust/app/base.py
+++ b/faust/app/base.py
@@ -1580,7 +1580,19 @@ class App(AppT, Service):
                         await T(consumer.transactions.on_partitions_revoked)(
                             revoked)
                 else:
-                    self.log.dev('ON P. REVOKED NOT COMMITTING: NO ASSIGNMENT')
+                    # With eager rebalance, assignment is empty because all
+                    # partitions are revoked at once. We must still stop the
+                    # flow and flush transactions to prevent zombie partitions
+                    # from processing without committing offsets.
+                    self.log.dev('ON P. REVOKED WITH EMPTY ASSIGNMENT')
+                    on_timeout.info('flow_control.suspend() (empty assignment)')
+                    await T(consumer.stop_flow)()
+                    T(self.flow_control.suspend)()
+                    T(self.flow_control.clear)()
+                    await T(self._producer_flush)(on_timeout)
+                    if self.in_transaction:
+                        await T(consumer.transactions.on_partitions_revoked)(
+                            revoked)
                 on_timeout.info('+send signal: on_partitions_revoked')
                 await T(self.on_partitions_revoked.send)(revoked)
                 on_timeout.info('-send signal: on_partitions_revoked')

--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -538,6 +538,22 @@ class Consumer(Service, ConsumerT):
         tps = self._active_partitions
         if tps is None:
             return self._set_active_tps(self.assignment())
+        # Reconcile: remove any TPs no longer in actual assignment
+        # to prevent zombie partitions that process without committing.
+        assignment = self.assignment()
+        if assignment:
+            orphaned = tps - assignment
+            if orphaned:
+                self.log.warning(
+                    'Removing orphaned partitions from active set '
+                    '(not in assignment): %r', orphaned,
+                )
+                tps.difference_update(orphaned)
+                for tp in orphaned:
+                    self._acked.pop(tp, None)
+                    self._acked_index.pop(tp, None)
+                    self._read_offset.pop(tp, None)
+                    self._committed_offset.pop(tp, None)
         assert all(isinstance(x, TP) for x in tps)
         return tps
 
@@ -1001,7 +1017,7 @@ class Consumer(Service, ConsumerT):
             else:
                 revoked[tp] = offset
         if revoked:
-            self.log.info(
+            self.log.warning(
                 'Discarded commit for revoked partitions that '
                 'will be eventually processed again: %r',
                 revoked,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.17.12
+current_version = 1.17.13
 commit = true
 tag = true
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<releaselevel>[a-z]+)?


### PR DESCRIPTION
Prevent zombie partition processing on eager rebalances by handling empty assignments during partition revocation:
* suspend/stop flow, clear flow control, flush producer, and invoke transaction revocation when in a transaction.
* Reconcile Consumer active partitions by removing orphaned TPs not in the current assignment and cleaning related state maps
* promote logs about discarded commits for revoked partitions to warnings. 
* Also bump package version to 1.17.13.