### PR TITLE
Add partition-aware prefix scans and bump version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Note: This project is a fork of the original **Faust** stream processing library
 
 |build-status| |coverage| |license| |wheel| |pyversion| |pyimp|
 
-:Version: 1.17.15
+:Version: 1.17.16
 :Web: http://faust.readthedocs.io/
 :Download: http://pypi.org/project/faust
 :Source: http://github.com/robinhood/faust

--- a/faust/__init__.py
+++ b/faust/__init__.py
@@ -24,7 +24,7 @@ import typing
 
 from typing import Any, Mapping, NamedTuple, Optional, Sequence, Tuple
 
-__version__ = '1.17.15'
+__version__ = '1.17.16'
 __author__ = 'Robinhood Markets, Inc.'
 __contact__ = 'contact@fauststream.com'
 __homepage__ = 'http://faust.readthedocs.io/'

--- a/faust/stores/base.py
+++ b/faust/stores/base.py
@@ -112,6 +112,9 @@ class Store(StoreT[KT, VT], Service):
     def prefix_scan(self, prefix: bytes) -> Iterator[Tuple[bytes, bytes]]:
         ...
 
+    def prefix_scan_for_partition(self, prefix: bytes, partition: int) -> Iterator[Tuple[bytes, bytes]]:
+        ...
+
     @property
     def label(self) -> str:
         """Return short description of this store."""
@@ -188,7 +191,11 @@ class SerializedStore(Store[KT, VT]):
         ...
 
     @abc.abstractmethod
-    def _prefix_scan(self, prefix: bytes) -> Iterator[Tuple[bytes, bytes]]:  # pragma: no cover
+    def _prefix_scan(self, prefix: bytes, partition: int = None) -> Iterator[Tuple[bytes, bytes]]:  # pragma: no cover
+        ...
+
+    @abc.abstractmethod
+    def _iteritems_for_partition(self, partition: int) -> Iterator[Tuple[bytes, bytes]]:  # pragma: no cover
         ...
 
     def apply_changelog_batch(self, batch: Iterable[EventT],
@@ -270,12 +277,17 @@ class SerializedStore(Store[KT, VT]):
     def del_for_partition(self, key, partition: int) -> None:
         return self._del(self._encode_key(key), partition=partition)
     
-    def prefix_scan(self, prefix: KT) -> Iterator[Tuple[KT, VT]]:
+    def prefix_scan(self, prefix: KT, partition: int = None) -> Iterator[Tuple[KT, VT]]:
         # json serializer wraps prefix value in quotes
         # we truncate the last quote character to ensure the prefix is matched
         if self.key_serializer == 'json':
             _prefix = self._encode_key(prefix)[:-1]
         else:
             _prefix = self._encode_key(prefix)
-        for key, value in self._prefix_scan(_prefix):
+        for key, value in self._prefix_scan(_prefix, partition=partition):
+            yield self._decode_key(key), self._decode_value(value)
+
+    def items_for_partition(self, partition: int) -> Iterator[Tuple[KT, VT]]:
+        """Iterate all (key, value) pairs in a specific partition."""
+        for key, value in self._iteritems_for_partition(partition):
             yield self._decode_key(key), self._decode_value(value)    

--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -730,6 +730,10 @@ class Store(base.SerializedStore):
         for db in self._dbs_for_actives():
             yield from self._visible_items(db)
 
+    def _iteritems_for_partition(self, partition: int) -> Iterator[Tuple[bytes, bytes]]:
+        db = self._db_for_partition(partition)
+        yield from self._visible_items(db)
+
     def _clear(self) -> None:
         raise NotImplementedError("TODO")  # XXX cannot reset tables
 
@@ -755,7 +759,7 @@ class Store(base.SerializedStore):
         # not work if the table name has dots in it (Issue #184).
         return path.with_name(f"{path.name}{suffix}")
 
-    def _prefix_scan(self, prefix: bytes) -> Iterator[Tuple[bytes, bytes]]:
+    def _prefix_scan(self, prefix: bytes, partition: int = None) -> Iterator[Tuple[bytes, bytes]]:
         if (
             self.rocksdb_options.prefix_extractor_enabled
             and len(prefix) > self.rocksdb_options.prefix_max_length
@@ -769,7 +773,11 @@ class Store(base.SerializedStore):
         if self.use_rocksdict:
             read_options = rocksdict.ReadOptions()
             read_options.set_prefix_same_as_start(True)
-            for db in self._dbs_for_actives():
+            if partition is not None:
+                dbs = [self._db_for_partition(partition)]
+            else:
+                dbs = self._dbs_for_actives()
+            for db in dbs:
                 it = db.iter(read_options)
                 it.seek(prefix)
                 while it.valid():

--- a/faust/tables/base.py
+++ b/faust/tables/base.py
@@ -651,9 +651,13 @@ class Collection(Service, CollectionT):
         if self._on_changelog_event:
             await self._on_changelog_event(event)
 
-    def prefix_scan(self, prefix: Any) -> Iterator[Tuple[Any, Any]]:
+    def prefix_scan(self, prefix: Any, partition: int = None) -> Iterator[Tuple[Any, Any]]:
         """Scan table for keys matching a prefix."""
-        yield from self.data.prefix_scan(prefix)
+        yield from self.data.prefix_scan(prefix, partition=partition)
+
+    def items_for_partition(self, partition: int) -> Iterator[Tuple[Any, Any]]:
+        """Iterate all (key, value) pairs in a specific partition."""
+        yield from self.data.items_for_partition(partition)
         
     @property
     def label(self) -> str:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.17.15
+current_version = 1.17.16
 commit = true
 tag = true
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<releaselevel>[a-z]+)?


### PR DESCRIPTION
Add support for scanning and iterating items scoped to a specific partition. API changes: prefix_scan now accepts an optional partition argument across stores and tables