### PR TITLE
Add request_rejoin to consumers

### DIFF
--- a/faust/__init__.py
+++ b/faust/__init__.py
@@ -24,7 +24,7 @@ import typing
 
 from typing import Any, Mapping, NamedTuple, Optional, Sequence, Tuple
 
-__version__ = '1.17.17'
+__version__ = '1.17.18'
 __author__ = 'Robinhood Markets, Inc.'
 __contact__ = 'contact@fauststream.com'
 __homepage__ = 'http://faust.readthedocs.io/'

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -281,6 +281,10 @@ class Consumer(ThreadDelegateConsumer):
             tp,
         )
 
+    def request_rejoin(self) -> None:
+        """Request the consumer to rejoin the group (trigger rebalance)."""
+        self._thread.request_rejoin()
+
     async def on_stop(self) -> None:
         """Call when consumer is stopping."""
         await super().on_stop()
@@ -795,6 +799,11 @@ class AIOKafkaConsumerThread(ConsumerThread):
         else:
             return cast(Mapping[TP, int],
                         await consumer.end_offsets(partitions))
+
+    def request_rejoin(self) -> None:
+        """Request the consumer to rejoin the group (trigger rebalance)."""
+        consumer = self._ensure_consumer()
+        consumer._coordinator.request_rejoin()
 
     def _ensure_consumer(self) -> aiokafka.AIOKafkaConsumer:
         if self._consumer is None:

--- a/faust/types/transports.py
+++ b/faust/types/transports.py
@@ -406,6 +406,10 @@ class ConsumerT(ServiceT):
         ...
 
     @abc.abstractmethod
+    def request_rejoin(self) -> None:
+        ...
+
+    @abc.abstractmethod
     def verify_recovery_event_path(self, now: float, tp: TP) -> None:
         ...
 


### PR DESCRIPTION
Expose a request_rejoin API to force a consumer group rejoin (trigger rebalance). Added ThreadDelegateConsumer.request_rejoin to forward the call to the consumer thread, and implemented AIOKafkaConsumerThread.request_rejoin to call consumer._coordinator.request_rejoin(). Also added the abstract request_rejoin method to the ConsumerT interface and bumped package version to 1.17.18.