### PR TITLE
Handle missing metadata in key partitioning

### DIFF
--- a/faust/__init__.py
+++ b/faust/__init__.py
@@ -24,7 +24,7 @@ import typing
 
 from typing import Any, Mapping, NamedTuple, Optional, Sequence, Tuple
 
-__version__ = '1.17.18'
+__version__ = '1.17.19'
 __author__ = 'Robinhood Markets, Inc.'
 __contact__ = 'contact@fauststream.com'
 __homepage__ = 'http://faust.readthedocs.io/'

--- a/faust/transport/drivers/aiokafka.py
+++ b/faust/transport/drivers/aiokafka.py
@@ -1690,6 +1690,15 @@ class Producer(base.Producer):
     def key_partition(self, topic: str, key: bytes) -> TP:
         """Hash key to determine partition destination."""
         producer = self._ensure_producer()
+        client = producer.client
+        if client is None:
+            raise NotReady('Producer client not yet connected')
+        if producer._metadata.partitions_for_topic(topic) is None:
+            client.add_topic(topic)
+            client.force_metadata_update()
+            raise NotReady(
+                f'Producer metadata for topic {topic!r} not available yet'
+            )
         partition = producer._partition(
             topic,
             partition=None,

--- a/t/unit/transport/drivers/test_aiokafka.py
+++ b/t/unit/transport/drivers/test_aiokafka.py
@@ -1582,6 +1582,21 @@ class test_Producer:
         x = producer.key_partition('topic', 'k')
         assert x == TP('topic', _producer._partition.return_value)
 
+    def test_key_partition__no_metadata(self, *, producer, _producer):
+        _producer.client = Mock(
+            name='client',
+            add_topic=Mock(),
+            force_metadata_update=Mock(),
+        )
+        _producer._metadata = Mock(name='metadata')
+        _producer._metadata.partitions_for_topic.return_value = None
+
+        with pytest.raises(NotReady, match="metadata for topic 'topic' not available"):
+            producer.key_partition('topic', 'k')
+
+        _producer.client.add_topic.assert_called_once_with('topic')
+        _producer.client.force_metadata_update.assert_called_once_with()
+
     def test_supports_headers(self, *, producer):
         producer._producer.client.api_version = (0, 11)
         assert producer.supports_headers()


### PR DESCRIPTION
Guard `Producer.key_partition` against missing topic metadata by checking client/metadata readiness before partition selection. When metadata is unavailable, the producer now requests a metadata refresh (`add_topic` + `force_metadata_update`) and raises `NotReady` instead of proceeding. Added a unit test to verify the new `NotReady` path and refresh calls.