### PR TITLE
Snapshot active partitions per poll batch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Note: This project is a fork of the original **Faust** stream processing library
 
 |build-status| |coverage| |license| |wheel| |pyversion| |pyimp|
 
-:Version: 1.17.17
+:Version: 1.17.20
 :Web: http://faust.readthedocs.io/
 :Download: http://pypi.org/project/faust
 :Source: http://github.com/robinhood/faust

--- a/faust/__init__.py
+++ b/faust/__init__.py
@@ -24,7 +24,7 @@ import typing
 
 from typing import Any, Mapping, NamedTuple, Optional, Sequence, Tuple
 
-__version__ = '1.17.19'
+__version__ = '1.17.20'
 __author__ = 'Robinhood Markets, Inc.'
 __contact__ = 'contact@fauststream.com'
 __homepage__ = 'http://faust.readthedocs.io/'

--- a/faust/transport/consumer.py
+++ b/faust/transport/consumer.py
@@ -763,7 +763,10 @@ class Consumer(Service, ConsumerT):
         if is_client_only:
             active_partitions = None
         else:
-            active_partitions = self._get_active_partitions()
+            # Snapshot active partitions once per poll so pause/resume only
+            # affects future fetches instead of filtering records already
+            # drained for this batch.
+            active_partitions = self._get_active_partitions().copy()
 
         records: RecordMap = {}
         if is_client_only or active_partitions:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.17.17
+current_version = 1.17.20
 commit = true
 tag = true
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<releaselevel>[a-z]+)?

--- a/t/unit/transport/test_consumer.py
+++ b/t/unit/transport/test_consumer.py
@@ -501,6 +501,36 @@ class test_Consumer:
         ]
 
     @pytest.mark.asyncio
+    async def test_getmany__pause_only_affects_next_poll(self, *, consumer):
+        consumer._to_message = lambda tp, record: record
+        self._setup_records(
+            consumer,
+            active_partitions={TP1, TP2},
+            records={
+                TP1: ['A', 'B'],
+                TP2: ['C', 'D'],
+            },
+        )
+        consumer.scheduler = Mock()
+
+        def se(records):
+            yield TP1, 'A'
+            consumer.pause_partitions([TP2])
+            yield TP2, 'C'
+            yield TP1, 'B'
+            yield TP2, 'D'
+
+        consumer.scheduler.iterate.side_effect = se
+
+        assert [a async for a in consumer.getmany(1.0)] == [
+            (TP1, 'A'),
+            (TP2, 'C'),
+            (TP1, 'B'),
+            (TP2, 'D'),
+        ]
+        assert consumer._active_partitions == {TP1}
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize('client_only', [
         False,
         True,
@@ -517,6 +547,27 @@ class test_Consumer:
         expected_active = None if client_only else {TP1}
         ret = await consumer._wait_next_records(1.0)
         assert ret == ({TP1: ['A', 'B', 'C']}, expected_active)
+
+    @pytest.mark.asyncio
+    async def test__wait_next_records__returns_active_partition_snapshot(
+            self, *, consumer):
+        self._setup_records(
+            consumer,
+            active_partitions={TP1, TP2},
+            records={
+                TP1: ['A'],
+                TP2: ['B'],
+            },
+        )
+
+        records, active_partitions = await consumer._wait_next_records(1.0)
+
+        assert records == {
+            TP1: ['A'],
+            TP2: ['B'],
+        }
+        assert active_partitions == {TP1, TP2}
+        assert active_partitions is not consumer._active_partitions
 
     @pytest.mark.asyncio
     async def test__wait_next_records__flow_inactive(self, *, consumer):


### PR DESCRIPTION
Make `_wait_next_records` copy the active partition set once per poll so pause/resume changes only affect future fetches, not records already drained in the current batch. Added unit tests to cover mid-iteration pause behavior in `getmany` and to assert `_wait_next_records` returns a snapshot (not the live set).
